### PR TITLE
Update UnboundKeyException.php

### DIFF
--- a/app/Exceptions/UnboundKeyException.php
+++ b/app/Exceptions/UnboundKeyException.php
@@ -11,19 +11,7 @@ use Throwable;
  */
 class UnboundKeyException extends Exception
 {
-    /**
-     * UnboundKeyException constructor.
-     * @param string $message
-     * @param int $code
-     * @param Throwable|null $previous
-     */
-    public function __construct(
-        $message = '
-            The requested key-value pair is not bound to this container
-        ',
-        $code = 0,
-        Throwable $previous = null
-    ){
-        parent::__construct($message, $code, $previous);
-    }
+    // Per a discussion with Steve, this will work because 
+    // it will be passed to the constructor automatically.
+    public $message = 'The requested key-value pair is not bound to this container.';
 }


### PR DESCRIPTION
Additionally, per discussion with Steve, we don't need custom exceptions at all because there's only one case.
If there's more than one type of exception, it makes sense to start using PHPs built in exception types or making your own.